### PR TITLE
Handle payment code already exists + cargo fmt + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Smart contracts using [Odra Framework](https://github.com/odradev/odra).
 Note that the Odra is still under heavy development.
 
 ## Prepare
-First install Rust, Make and Git.
+First install Rust, Make, WebAssembly Binary Toolkit (wabt), Perl and Git.
 
 Install Cargo Odra.
 ```bash
@@ -24,6 +24,15 @@ $ rustup target add wasm32-unknown-unknown
 Add `wasm-strip`.
 ```bash
 $ sudo apt install wabt
+# or for Fedora
+$ sudo dnf install wabt
+```
+
+Install Perl
+```bash
+$ sudo apt install perl
+# or for Fedora
+$ sudo dnf install perl-core
 ```
 
 ## Test on MockVM

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod payment;
-pub use payment::{MasterPaymentCode, MasterPaymentCodeRef, PersonalPaymentCodeSignalling, PersonalPaymentCodeSignallingRef};
+pub use payment::{
+    MasterPaymentCode, MasterPaymentCodeRef, PersonalPaymentCodeSignalling,
+    PersonalPaymentCodeSignallingRef,
+};


### PR DESCRIPTION
- Add new error type `PaymentCodeAlreadyExists` which is triggered when we want to add the same payment code to `MasterPaymentCode` contract for a different unique name.
- Update unit test
- README update for Perl installation
- cargo fmt